### PR TITLE
Add UofL education section to lab page, update master's to UofL HR & OD

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,8 +188,8 @@
           </p>
           <p>
             Currently finishing a B.S. in Organizational Leadership and Learning at the
-            University of Louisville (4.0 GPA, expected 2026), with an M.S. in Instructional
-            Design and Technology at the University of Kentucky beginning January 2027.
+            University of Louisville (4.0 GPA, expected 2026), with an M.S. in Human Resources
+            &amp; Organization Development at the University of Louisville beginning January 2027.
           </p>
         </div>
         <div class="about-award-wrap">

--- a/lab.html
+++ b/lab.html
@@ -147,12 +147,34 @@
             <h4>Modular LXD for AI-Era Workforce Change</h4>
             <p class="sidebar-p">When job functions are shifting faster than curriculum can keep up, what does "designed for change" look like at the course level?</p>
           </div>
-          <div class="now-item">
-            <img src="assets/uofl-logo.webp" alt="University of Louisville" class="uofl-logo" />
-            <h4>UofL — Organizational Leadership &amp; Learning</h4>
-            <p class="sidebar-p">B.S. expected 2026 · 4.0 GPA · M.S. in Instructional Design &amp; Technology (University of Kentucky) beginning Jan 2027.</p>
-          </div>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <hr class="divider" />
+
+  <!-- ── EDUCATION ── -->
+  <section id="education" aria-labelledby="education-heading">
+    <div class="container">
+      <span class="label">Academic Work</span>
+      <h2 id="education-heading" class="heading section-h2-sm">University of Louisville</h2>
+
+      <div class="research-main reveal">
+        <img src="assets/uofl-logo.webp" alt="University of Louisville" class="uofl-logo" />
+        <p>
+          Currently completing a <strong>B.S. in Organizational Leadership and Learning</strong> (4.0 GPA, expected 2026) —
+          a skills-driven program that blends leadership theory, workforce development, and organizational change across
+          specialized tracks including human resources, project management, and healthcare leadership.
+        </p>
+        <p>
+          Next up: an <strong>M.S. in Human Resources &amp; Organization Development</strong> at UofL, beginning January 2027.
+          The through-line across both programs is learning how organizations change — and how to design learning
+          that actually drives that change.
+        </p>
+        <a href="https://louisville.edu/online/programs/bachelors/bachelor-of-science-in-organizational-leadership-and-learning" target="_blank" rel="noopener noreferrer" class="btn-ghost" style="width:fit-content">
+          View Program →
+        </a>
       </div>
     </div>
   </section>

--- a/resume.html
+++ b/resume.html
@@ -213,8 +213,8 @@
           <div>
             <div class="r-edu-entry">
               <div>
-                <p class="r-edu-degree">M.S. in Instructional Design &amp; Technology</p>
-                <p class="r-edu-school">University of Kentucky</p>
+                <p class="r-edu-degree">M.S. in Human Resources &amp; Organization Development</p>
+                <p class="r-edu-school">University of Louisville</p>
               </div>
               <span class="r-edu-year">Beginning Jan 2027</span>
             </div>


### PR DESCRIPTION
Promote the University of Louisville card from a sidebar item to a full-width section between Research & Writing and Tinkering on lab.html, with program description and link. Update master's degree across all pages from UK Instructional Design & Technology to UofL Human Resources & Organization Development.